### PR TITLE
Add manual transaction support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ output_modules:
   csv:    "transaction_tracker.outputs.csv_output.CSVOutput"
   sheets: "transaction_tracker.outputs.sheets_output.SheetsOutput"
 
+# Optional YAML listing any cash or other manual transactions
+manual_transactions_file: manual.yaml
+
 categories:
   restaurants: [...]
   groceries:   [...]
@@ -101,9 +104,28 @@ pip install gspread google-auth google-api-python-client
 ```bash
 # Process all statements in a directory, exclude payments:
 budgify --dir ~/Downloads/statements --output csv
+# You can optionally specify a different YAML of manual transactions
+# budgify --dir ~/Downloads/statements --manual-file my_manual.yaml --output csv
 ```
 
 Results:  `data/Budget2025.csv` (for year 2025), deduped and sorted by date.
+
+### Manual Transactions
+
+Any cash purchases or other expenses not present in bank statements can be
+listed in a small YAML file. Set `manual_transactions_file` in `config.yaml` or
+provide `--manual-file` on the command line.
+
+Example `manual.yaml`:
+
+```yaml
+- date: 2025-05-05
+  description: Farmers Market
+  merchant: CASH
+  amount: 23.50
+```
+
+These entries are loaded alongside statement data and deduplicated.
 
 ### Google Sheets Export
 

--- a/manual.yaml
+++ b/manual.yaml
@@ -1,0 +1,9 @@
+# Example manual transactions
+- date: 2025-05-05
+  description: Farmers Market
+  merchant: CASH
+  amount: 23.50
+- date: 2025-05-10
+  description: Babysitter
+  merchant: CASH
+  amount: 60

--- a/transaction_tracker/manual.py
+++ b/transaction_tracker/manual.py
@@ -1,5 +1,5 @@
 # transaction_tracker/manual.py
-from datetime import datetime
+from datetime import datetime, date
 import yaml
 from transaction_tracker.core.models import Transaction
 
@@ -11,11 +11,17 @@ def load_manual_transactions(path):
 
     txs = []
     for entry in data:
-        date_str = entry.get('date')
-        if not date_str:
+        date_val = entry.get('date')
+        if not date_val:
             raise ValueError(f"Missing 'date' in manual entry: {entry}")
+        if isinstance(date_val, date):
+            d = date_val
+        elif isinstance(date_val, str):
+            d = datetime.fromisoformat(date_val).date()
+        else:
+            raise ValueError(f"Unrecognized date format in manual entry: {entry}")
         tx = Transaction(
-            date=datetime.fromisoformat(date_str).date(),
+            date=d,
             description=entry.get('description', ''),
             merchant=entry.get('merchant', ''),
             amount=float(entry.get('amount', 0.0)),

--- a/transaction_tracker/manual.py
+++ b/transaction_tracker/manual.py
@@ -1,0 +1,24 @@
+# transaction_tracker/manual.py
+from datetime import datetime
+import yaml
+from transaction_tracker.core.models import Transaction
+
+
+def load_manual_transactions(path):
+    """Load manual transactions from a YAML file."""
+    with open(path) as f:
+        data = yaml.safe_load(f) or []
+
+    txs = []
+    for entry in data:
+        date_str = entry.get('date')
+        if not date_str:
+            raise ValueError(f"Missing 'date' in manual entry: {entry}")
+        tx = Transaction(
+            date=datetime.fromisoformat(date_str).date(),
+            description=entry.get('description', ''),
+            merchant=entry.get('merchant', ''),
+            amount=float(entry.get('amount', 0.0)),
+        )
+        txs.append(tx)
+    return txs


### PR DESCRIPTION
## Summary
- support loading manual cash transactions from YAML
- read manual YAML via CLI option or config
- document manual transaction usage

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6853f73bd9388323bbf6fb43b9dbd2e7