### PR TITLE
Fix e2e tests and document running them

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,17 @@ This will create (or update) a **"Budget 2025"** workbook in your Drive folder, 
 3. Update documentation.
 4. Submit a pull request.
 
+## Testing
+
+Budgify's tests require `pytest` and `PyYAML`. Install dependencies and run:
+
+```bash
+pip install -r requirements.txt
+pytest -q
+```
+
+Google Sheets APIs are mocked, so the test suite runs offline.
+
 ## License
 
 Released under the [MIT License](LICENSE).

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,235 @@
+import os
+import csv
+import sys
+import types
+import yaml
+from click.testing import CliRunner
+
+# Provide minimal google modules so sheets_output can be imported without
+# installing heavy dependencies.
+fake_gspread = types.ModuleType("gspread")
+fake_gspread.exceptions = types.SimpleNamespace(
+    SpreadsheetNotFound=Exception, WorksheetNotFound=Exception
+)
+fake_gspread.authorize = lambda *_a, **_k: None
+
+fake_service_account = types.ModuleType("google.oauth2.service_account")
+
+class FakeCreds:
+    @classmethod
+    def from_service_account_file(cls, *_a, **_k):
+        return cls()
+
+fake_service_account.Credentials = FakeCreds
+
+fake_discovery = types.ModuleType("googleapiclient.discovery")
+
+def fake_build(*_a, **_k):
+    class Dummy:
+        def __getattr__(self, name):
+            return lambda *a, **k: self
+
+    return Dummy()
+
+fake_discovery.build = fake_build
+
+sys.modules.setdefault("gspread", fake_gspread)
+sys.modules.setdefault("google.oauth2.service_account", fake_service_account)
+sys.modules.setdefault("googleapiclient.discovery", fake_discovery)
+
+from transaction_tracker.cli import main as cli
+from transaction_tracker.outputs import sheets_output
+
+
+def write_config(tmp_path, data_dir):
+    cfg = {
+        'bank_loaders': {
+            'tdvisa': 'transaction_tracker.loaders.tdvisa.TDVisaLoader',
+        },
+        'output_modules': {
+            'csv': 'transaction_tracker.outputs.csv_output.CSVOutput',
+            'sheets': 'transaction_tracker.outputs.sheets_output.SheetsOutput',
+        },
+        'categories': {
+            'restaurants': ['restaurant'],
+            'groceries': ['grocery'],
+        },
+        'output_dir': str(data_dir),
+        'google': {
+            'service_account_file': 'creds.json',
+            'sheet_folder_id': 'folder',
+            'owner_email': 'owner@example.com',
+        },
+    }
+    path = tmp_path / 'config.yaml'
+    with open(path, 'w') as f:
+        yaml.safe_dump(cfg, f)
+    return path
+
+
+def write_tdvisa_sample(path):
+    rows = [
+        ['05/02/2025', 'Grocery Store', '56.78', '', '1000'],
+        ['05/03/2025', 'Restaurant A', '12.34', '', '990'],
+    ]
+    with open(path, 'w', newline='') as f:
+        csv.writer(f).writerows(rows)
+
+
+def write_manual(path):
+    path.write_text(
+        """\
+- date: 2025-05-04
+  description: Farmers Market
+  merchant: CASH
+  amount: 10
+"""
+    )
+
+
+def test_cli_csv_output(tmp_path):
+    stmts = tmp_path / 'stmts'
+    stmts.mkdir()
+    td_file = stmts / 'tdvisa.csv'
+    write_tdvisa_sample(td_file)
+    manual = tmp_path / 'manual.yaml'
+    write_manual(manual)
+    cfg_path = write_config(tmp_path, tmp_path / 'data')
+
+    runner = CliRunner()
+    res = runner.invoke(
+        cli,
+        ['--dir', str(stmts), '--output', 'csv', '--config', str(cfg_path), '--manual-file', str(manual)]
+    )
+    assert res.exit_code == 0, res.output
+    out_csv = tmp_path / 'data' / 'Budget2025.csv'
+    assert out_csv.exists()
+    with open(out_csv) as f:
+        lines = [l.strip() for l in f]
+    assert lines[0] == 'date,description,merchant,category,amount'
+    assert len(lines) == 4  # header + 3 rows
+    assert any('restaurants' in l for l in lines[1:])
+    assert any('groceries' in l for l in lines[1:])
+
+
+class FakeWorksheet:
+    def __init__(self, title):
+        self.title = title
+        self.rows = []
+        self.spreadsheet = types.SimpleNamespace(id='123')
+
+    def update_title(self, title):
+        self.title = title
+
+    def clear(self):
+        self.rows = []
+
+    def update(self, *_args, **_kwargs):
+        if _args:
+            self.rows = _args[1]
+
+    def get_all_values(self):
+        return self.rows
+
+
+class FakeSpreadsheet:
+    def __init__(self):
+        self.id = '123'
+        self.sheet1 = FakeWorksheet('Sheet1')
+        self._worksheets = [self.sheet1]
+
+    def worksheet(self, title):
+        for ws in self._worksheets:
+            if ws.title == title:
+                return ws
+        raise sheets_output.gspread.exceptions.WorksheetNotFound
+
+    def add_worksheet(self, title, rows='100', cols='10'):
+        ws = FakeWorksheet(title)
+        self._worksheets.append(ws)
+        return ws
+
+    def worksheets(self):
+        return self._worksheets
+
+    def share(self, *_a, **_k):
+        pass
+
+
+def setup_sheet_mocks(monkeypatch):
+    class FakeCreds:
+        @classmethod
+        def from_service_account_file(cls, *_a, **_k):
+            return cls()
+
+    class FakeClient:
+        def __init__(self):
+            self.sheet = FakeSpreadsheet()
+
+        def open(self, *_a, **_k):
+            raise sheets_output.gspread.exceptions.SpreadsheetNotFound
+
+        def create(self, *_a, **_k):
+            return self.sheet
+
+    class FakeExceptions:
+        class SpreadsheetNotFound(Exception):
+            pass
+
+        class WorksheetNotFound(Exception):
+            pass
+
+    def fake_build(*_a, **_k):
+        class Dummy:
+            def files(self):
+                return self
+            def get(self, *a, **k):
+                fields = k.get('fields', '')
+                if 'parents' in fields:
+                    data = {'parents': []}
+                elif 'sheets.properties' in fields:
+                    data = {
+                        'sheets': [
+                            {'properties': {'title': 'Sheet1', 'sheetId': 1}},
+                            {'properties': {'title': 'May 2025', 'sheetId': 2}},
+                            {'properties': {'title': 'AllData', 'sheetId': 3}},
+                            {'properties': {'title': 'Summary', 'sheetId': 4}},
+                        ]
+                    }
+                else:
+                    data = {}
+                return types.SimpleNamespace(execute=lambda: data)
+            def update(self, *a, **k):
+                return types.SimpleNamespace(execute=lambda: {})
+            def spreadsheets(self):
+                return self
+            def batchUpdate(self, *a, **k):
+                return types.SimpleNamespace(execute=lambda: {})
+        return Dummy()
+
+    monkeypatch.setattr(sheets_output, 'Credentials', FakeCreds)
+    monkeypatch.setattr(
+        sheets_output,
+        'gspread',
+        types.SimpleNamespace(authorize=lambda *_a, **_k: FakeClient(), exceptions=FakeExceptions)
+    )
+    monkeypatch.setattr(sheets_output, 'build', fake_build)
+
+
+def test_cli_sheets_output(tmp_path, monkeypatch):
+    setup_sheet_mocks(monkeypatch)
+    stmts = tmp_path / 'stmts'
+    stmts.mkdir()
+    td_file = stmts / 'tdvisa.csv'
+    write_tdvisa_sample(td_file)
+    manual = tmp_path / 'manual.yaml'
+    write_manual(manual)
+    cfg_path = write_config(tmp_path, tmp_path / 'data')
+
+    runner = CliRunner()
+    res = runner.invoke(
+        cli,
+        ['--dir', str(stmts), '--output', 'sheets', '--config', str(cfg_path), '--manual-file', str(manual)]
+    )
+    assert res.exit_code == 0, res.output
+    assert 'Appended 3 transaction' in res.output


### PR DESCRIPTION
## Summary
- make fake google modules so SheetsOutput imports without dependencies
- update end-to-end tests to use the fakes
- add test instructions to the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853ff31505083239244fc9c76a20c91