### PR TITLE
Refactor AI layer with composable client

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,11 +167,12 @@ This will create (or update) a **"Budget 2025"** workbook in your Drive folder, 
 ### AI Report
 
 Pass `--ai-report` when running Budgify to send the final list of
-transactions to an LLM for analysis. By default the Hugging Face
-Inference API is used via the **Cerebras** provider. Set `HF_API_TOKEN`
-and optionally `BUDGIFY_LLM_MODEL` to choose the model. To use OpenAI
-instead set `BUDGIFY_LLM_PROVIDER=openai` and provide `OPENAI_API_KEY`.
-You can keep these variables in a `.env` file and load it with
+transactions to an LLM for analysis.  `transaction_tracker.ai` exposes an
+`LLMClient` capable of using multiple providers (Hugging Face or OpenAI
+via environment variables) and composable output layers.  The default
+`InsightsReport` class is used by the CLI.  Configure your provider with
+`HF_API_TOKEN` or `OPENAI_API_KEY` (and `BUDGIFY_LLM_PROVIDER=openai`).
+These variables can be stored in a `.env` file and loaded with
 `--env-file path/to/.env`.
 
 ## Extending

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,0 +1,16 @@
+from transaction_tracker.ai import LLMClient, InsightsReport
+from transaction_tracker.core.models import Transaction
+from datetime import date
+
+class DummyProvider:
+    def __init__(self):
+        self.messages = []
+    def generate(self, messages):
+        self.messages.append(messages)
+        return "ok"
+
+def test_insights_report_with_client():
+    tx = Transaction(date=date(2025, 5, 1), description="desc", merchant="m", amount=1.0)
+    client = LLMClient(provider=DummyProvider())
+    report = InsightsReport().generate([tx], client)
+    assert report == "ok"


### PR DESCRIPTION
## Summary
- add an extensible `LLMClient` and `BaseAIOutput`
- implement `InsightsReport` using the new structures
- update README docs
- test the new client

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68556e0774cc83238b960d8e7daa6c3f