### PR TITLE
Add MCP server and local LLM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,21 @@ via environment variables) and composable output layers.  The default
 These variables can be stored in a `.env` file and loaded with
 `--env-file path/to/.env`.
 
+To use a local LLM such as [Ollama](https://github.com/ollama/ollama), set
+`BUDGIFY_LLM_PROVIDER=ollama` and optionally `OLLAMA_URL` if your server is not
+running on `http://localhost:11434`.
+
+### MCP Server
+
+Budgify can be exposed as an MCP server so tools like a locally running LLM can
+invoke it directly. Install the optional `mcp` dependency and run:
+
+```bash
+budgify-mcp
+```
+
+This starts a FastMCP server exposing a single `run_budgify` tool.
+
 ## Extending
 
 ### Add a new bank loader

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ google-api-python-client>=2.0
 pytest>=6.0
 huggingface_hub>=0.33
 python-dotenv>=1.0
+mcp>=1.9
 

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,13 @@ setup(
         "google-api-python-client>=2.0.0",
         "huggingface_hub>=0.33",
         "python-dotenv>=1.0",
+        "mcp>=1.9",
 
     ],
     entry_points={
         "console_scripts": [
             "budgify=transaction_tracker.cli:main",
+            "budgify-mcp=transaction_tracker.mcp_server:main",
         ],
     },
     classifiers=[

--- a/transaction_tracker/ai/__init__.py
+++ b/transaction_tracker/ai/__init__.py
@@ -11,6 +11,7 @@ from abc import ABC, abstractmethod
 
 # -----------------------------------------------------------------------------
 # Configure basic debug logging (caller can override)
+
 # -----------------------------------------------------------------------------
 logging.basicConfig(level=os.getenv("LLM_DEBUG", "INFO").upper())
 logger = logging.getLogger(__name__)

--- a/transaction_tracker/ai/__init__.py
+++ b/transaction_tracker/ai/__init__.py
@@ -1,24 +1,34 @@
 import json
 import os
 import urllib.request
+import logging
 from dataclasses import dataclass
 from typing import List, Protocol
 
 from transaction_tracker.core.models import Transaction
-
 from huggingface_hub import InferenceClient
 from abc import ABC, abstractmethod
 
+# -----------------------------------------------------------------------------
+# Configure basic debug logging (caller can override)
+# -----------------------------------------------------------------------------
+logging.basicConfig(level=os.getenv("LLM_DEBUG", "INFO").upper())
+logger = logging.getLogger(__name__)
+
 _OLLAMA_URL = "http://localhost:11434/api/chat"
-
-
 _OPENAI_URL = "https://api.openai.com/v1/chat/completions"
 
 
 class LLMProvider(Protocol):
-    def generate(self, messages: List[dict]) -> str:
-        """Return a completion for the given chat messages."""
+    """A minimal protocol all concrete providers must implement."""
 
+    def generate(self, messages: List[dict]) -> str:  # noqa: D401 – keep simple signature
+        """Return the model reply given a list-of-dicts chat history."""
+
+
+# -----------------------------------------------------------------------------
+# Hugging Face Inference API provider (unchanged)
+# -----------------------------------------------------------------------------
 
 @dataclass
 class LLMClient:
@@ -45,6 +55,10 @@ class HuggingFaceProvider:
         out = self._client.chat_completion(messages=messages, model=self.model)
         return out.choices[0].message.content.strip()
 
+
+# -----------------------------------------------------------------------------
+# OpenAI Chat Completions provider (unchanged)
+# -----------------------------------------------------------------------------
 
 @dataclass
 class OpenAIProvider:
@@ -96,20 +110,44 @@ class InsightsReport(BaseAIOutput):
             },
             {"role": "user", "content": "\n".join(lines)},
         ]
+# -----------------------------------------------------------------------------
+# Ollama provider with robust parsing and debug logging
+# -----------------------------------------------------------------------------
+
 @dataclass
 class OllamaProvider:
     model: str
     url: str = _OLLAMA_URL
 
-    def generate(self, messages: List[dict]) -> str:
-        payload = {"model": self.model, "messages": messages, "stream": False}
+    def _post(self, payload: dict) -> dict:
+        """Low‑level helper: POST JSON and return parsed JSON with debug logs."""
         data = json.dumps(payload).encode()
+        logger.debug("Ollama ▶ POST %s – payload: %s", self.url, payload)
         req = urllib.request.Request(self.url, data=data, method="POST")
         req.add_header("Content-Type", "application/json")
-        with urllib.request.urlopen(req) as resp:
-            resp_data = json.load(resp)
-        return resp_data.get("message", {}).get("content", "").strip()
 
+        with urllib.request.urlopen(req) as resp:
+            raw = resp.read().decode()
+            logger.debug("Ollama ◀ %s", raw)
+            return json.loads(raw)
+
+    def generate(self, messages: List[dict]) -> str:
+        payload = {"model": self.model, "messages": messages, "stream": False}
+        resp_data = self._post(payload)
+
+        # Ollama /api/chat returns either {'message': str, 'done': bool}
+        # or {'message': {'role': 'assistant', 'content': str, ...}, 'done': bool}
+        msg = resp_data.get("message", "")
+        if isinstance(msg, dict):
+            msg = msg.get("content", "")
+        if not isinstance(msg, str):
+            raise RuntimeError(f"Unexpected Ollama response format: {resp_data}")
+        return msg.strip()
+
+
+# -----------------------------------------------------------------------------
+# Helper utilities
+# -----------------------------------------------------------------------------
 
 def _tx_to_line(tx: Transaction) -> str:
     return f"{tx.date.isoformat()} | {tx.description} | {tx.merchant} | {tx.amount:.2f}"
@@ -117,20 +155,28 @@ def _tx_to_line(tx: Transaction) -> str:
 
 def get_provider_from_env() -> LLMProvider:
     provider = os.environ.get("BUDGIFY_LLM_PROVIDER", "huggingface").lower()
+
     if provider == "openai":
         api_key = os.environ.get("OPENAI_API_KEY")
         if not api_key:
             raise RuntimeError("OPENAI_API_KEY not set")
         model = os.environ.get("BUDGIFY_LLM_MODEL", "gpt-3.5-turbo")
         return OpenAIProvider(model=model, api_key=api_key)
+
     if provider == "ollama":
-        model = os.environ.get("BUDGIFY_LLM_MODEL", "llama3")
+        model = os.environ.get("BUDGIFY_LLM_MODEL", "phi3:mini")
         url = os.environ.get("OLLAMA_URL", _OLLAMA_URL)
         return OllamaProvider(model=model, url=url)
+
+    # Default → Hugging Face
     token = os.environ.get("HF_API_TOKEN")
     model = os.environ.get("BUDGIFY_LLM_MODEL", "Qwen/Qwen3-32B")
     return HuggingFaceProvider(model=model, token=token)
 
+
+# -----------------------------------------------------------------------------
+# Public helper – generate a textual insights report
+# -----------------------------------------------------------------------------
 
 def generate_report(transactions: List[Transaction], provider: LLMProvider | None = None) -> str:
     """Convenience wrapper returning an insights report."""

--- a/transaction_tracker/mcp_server.py
+++ b/transaction_tracker/mcp_server.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import anyio
+from mcp.server.fastmcp import FastMCP
+
+from transaction_tracker.cli import main as cli
+
+server = FastMCP(name="Budgify", instructions="Expose Budgify as an MCP tool")
+
+@server.tool(name="run_budgify", description="Process statements using Budgify")
+async def run_budgify(
+    statements_dir: str,
+    output_format: str = "csv",
+    include_payments: bool = False,
+    config_path: str = "config.yaml",
+    manual_file: str | None = None,
+    env_file: str | None = None,
+    ai_report: bool = False,
+) -> str:
+    def _run() -> None:
+        cli.callback(
+            statements_dir,
+            output_format,
+            include_payments,
+            config_path,
+            manual_file,
+            env_file,
+            ai_report,
+        )
+
+    await anyio.to_thread.run_sync(_run)
+    return "Completed"
+
+
+def main() -> None:
+    server.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- support running Budgify through an MCP server
- allow Ollama as a local LLM provider
- document the MCP server and local LLM usage
- update dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b236a02d4832394812a6e1b5e4684