### PR TITLE
Add MCP server and local LLM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,21 @@ instead set `BUDGIFY_LLM_PROVIDER=openai` and provide `OPENAI_API_KEY`.
 You can keep these variables in a `.env` file and load it with
 `--env-file path/to/.env`.
 
+To use a local LLM such as [Ollama](https://github.com/ollama/ollama), set
+`BUDGIFY_LLM_PROVIDER=ollama` and optionally `OLLAMA_URL` if your server is not
+running on `http://localhost:11434`.
+
+### MCP Server
+
+Budgify can be exposed as an MCP server so tools like a locally running LLM can
+invoke it directly. Install the optional `mcp` dependency and run:
+
+```bash
+budgify-mcp
+```
+
+This starts a FastMCP server exposing a single `run_budgify` tool.
+
 ## Extending
 
 ### Add a new bank loader

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ google-api-python-client>=2.0
 pytest>=6.0
 huggingface_hub>=0.33
 python-dotenv>=1.0
+mcp>=1.9
 

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,13 @@ setup(
         "google-api-python-client>=2.0.0",
         "huggingface_hub>=0.33",
         "python-dotenv>=1.0",
+        "mcp>=1.9",
 
     ],
     entry_points={
         "console_scripts": [
             "budgify=transaction_tracker.cli:main",
+            "budgify-mcp=transaction_tracker.mcp_server:main",
         ],
     },
     classifiers=[

--- a/transaction_tracker/ai/__init__.py
+++ b/transaction_tracker/ai/__init__.py
@@ -8,6 +8,8 @@ from transaction_tracker.core.models import Transaction
 
 from huggingface_hub import InferenceClient
 
+_OLLAMA_URL = "http://localhost:11434/api/chat"
+
 
 _OPENAI_URL = "https://api.openai.com/v1/chat/completions"
 
@@ -46,6 +48,21 @@ class OpenAIProvider:
         return resp_data["choices"][0]["message"]["content"].strip()
 
 
+@dataclass
+class OllamaProvider:
+    model: str
+    url: str = _OLLAMA_URL
+
+    def generate(self, messages: List[dict]) -> str:
+        payload = {"model": self.model, "messages": messages, "stream": False}
+        data = json.dumps(payload).encode()
+        req = urllib.request.Request(self.url, data=data, method="POST")
+        req.add_header("Content-Type", "application/json")
+        with urllib.request.urlopen(req) as resp:
+            resp_data = json.load(resp)
+        return resp_data.get("message", {}).get("content", "").strip()
+
+
 def _tx_to_line(tx: Transaction) -> str:
     return f"{tx.date.isoformat()} | {tx.description} | {tx.merchant} | {tx.amount:.2f}"
 
@@ -58,6 +75,10 @@ def get_provider_from_env() -> LLMProvider:
             raise RuntimeError("OPENAI_API_KEY not set")
         model = os.environ.get("BUDGIFY_LLM_MODEL", "gpt-3.5-turbo")
         return OpenAIProvider(model=model, api_key=api_key)
+    if provider == "ollama":
+        model = os.environ.get("BUDGIFY_LLM_MODEL", "llama3")
+        url = os.environ.get("OLLAMA_URL", _OLLAMA_URL)
+        return OllamaProvider(model=model, url=url)
     token = os.environ.get("HF_API_TOKEN")
     model = os.environ.get("BUDGIFY_LLM_MODEL", "Qwen/Qwen3-32B")
     return HuggingFaceProvider(model=model, token=token)

--- a/transaction_tracker/mcp_server.py
+++ b/transaction_tracker/mcp_server.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import anyio
+from mcp.server.fastmcp import FastMCP
+
+from transaction_tracker.cli import main as cli
+
+server = FastMCP(name="Budgify", instructions="Expose Budgify as an MCP tool")
+
+@server.tool(name="run_budgify", description="Process statements using Budgify")
+async def run_budgify(
+    statements_dir: str,
+    output_format: str = "csv",
+    include_payments: bool = False,
+    config_path: str = "config.yaml",
+    manual_file: str | None = None,
+    env_file: str | None = None,
+    ai_report: bool = False,
+) -> str:
+    def _run() -> None:
+        cli.callback(
+            statements_dir,
+            output_format,
+            include_payments,
+            config_path,
+            manual_file,
+            env_file,
+            ai_report,
+        )
+
+    await anyio.to_thread.run_sync(_run)
+    return "Completed"
+
+
+def main() -> None:
+    server.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- support running Budgify through an MCP server
- allow Ollama as a local LLM provider
- document the MCP server and local LLM usage
- update dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b236a02d4832394812a6e1b5e4684