### PR TITLE
Fix sheet sharing logic

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -165,6 +165,9 @@ class FakeSpreadsheet:
     def share(self, *_a, **_k):
         pass
 
+    def list_permissions(self):
+        return [{'emailAddress': 'owner@example.com', 'role': 'writer'}]
+
 
 def setup_sheet_mocks(monkeypatch):
     class FakeCreds:

--- a/transaction_tracker/outputs/sheets_output.py
+++ b/transaction_tracker/outputs/sheets_output.py
@@ -68,7 +68,13 @@ class SheetsOutput(BaseOutput):
                     fields        = 'id,parents'
                 ).execute()
         if self.owner:
-            sh.share(self.owner, perm_type='user', role='writer')
+            try:
+                perms = sh.list_permissions()
+            except Exception:
+                perms = []
+            emails = {p.get('emailAddress') for p in perms}
+            if self.owner not in emails:
+                sh.share(self.owner, perm_type='user', role='writer')
 
         # 1) Monthly tabs
         for month_str in months:


### PR DESCRIPTION
## Summary
- don't share sheets when already shared
- adjust e2e mocks for new logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868631459488323b5168f8c77709697