### PR TITLE
Format Sheets output as sortable tables

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -13,6 +13,16 @@ fake_gspread.exceptions = types.SimpleNamespace(
     SpreadsheetNotFound=Exception, WorksheetNotFound=Exception
 )
 fake_gspread.authorize = lambda *_a, **_k: None
+fake_gspread.__path__ = []
+def _rowcol_to_a1(row, col):
+    letters = ""
+    while col:
+        col, rem = divmod(col - 1, 26)
+        letters = chr(rem + ord('A')) + letters
+    return f"{letters}{row}"
+fake_utils = types.ModuleType("gspread.utils")
+fake_utils.rowcol_to_a1 = _rowcol_to_a1
+fake_gspread.utils = fake_utils
 
 fake_service_account = types.ModuleType("google.oauth2.service_account")
 
@@ -35,6 +45,7 @@ def fake_build(*_a, **_k):
 fake_discovery.build = fake_build
 
 sys.modules.setdefault("gspread", fake_gspread)
+sys.modules.setdefault("gspread.utils", fake_utils)
 sys.modules.setdefault("google.oauth2.service_account", fake_service_account)
 sys.modules.setdefault("googleapiclient.discovery", fake_discovery)
 
@@ -162,6 +173,12 @@ class FakeWorksheet:
     def update(self, *_args, **_kwargs):
         if _args:
             self.rows = _args[1]
+
+    def set_basic_filter(self, *_a, **_k):
+        pass
+
+    def sort(self, *_a, **_k):
+        pass
 
     def get_all_values(self):
         # Simulate pivot-table columns appended to the right of transaction

--- a/tests/test_sheets_output.py
+++ b/tests/test_sheets_output.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock
+
+from transaction_tracker.outputs.sheets_output import SheetsOutput
+
+
+def test_apply_table_and_sort_monthly():
+    ws = MagicMock()
+    rows = [
+        ['date', 'description', 'merchant', 'category', 'amount'],
+        ['2024-01-01', 'Desc', 'Merc', 'Cat', 10.0],
+    ]
+    out = object.__new__(SheetsOutput)
+    out._apply_table_and_sort(ws, rows, amount_col=5)
+    ws.set_basic_filter.assert_called_once_with('A1:E2')
+    ws.sort.assert_called_once_with((5, 'des'), range='A2:E2')
+
+
+def test_apply_table_and_sort_alldata():
+    ws = MagicMock()
+    rows = [
+        ['month', 'date', 'description', 'merchant', 'category', 'amount'],
+        ['Jan', '2024-01-01', 'Desc', 'Merc', 'Cat', 20.0],
+    ]
+    out = object.__new__(SheetsOutput)
+    out._apply_table_and_sort(ws, rows, amount_col=6)
+    ws.set_basic_filter.assert_called_once_with('A1:F2')
+    ws.sort.assert_called_once_with((6, 'des'), range='A2:F2')


### PR DESCRIPTION
## Summary
- Format monthly and AllData worksheets as tables with filters and default sort on transaction amount
- Add helper to configure table filters and descending sort
- Cover table setup with unit tests and adjust e2e mocks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afb7e699008323936042b705040bcd