### PR TITLE
Sort Excel monthly data and generate manual summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,10 @@ Results:  `data/Budget2025.csv` (for year 2025), deduped and sorted by date.
 budgify --dir ~/Downloads/statements --output excel
 ```
 
-Generates a local `Budget2025.xlsx` workbook with monthly tabs, an `AllData` tab,
-and a `Summary` sheet summarizing amounts by month and category.
+Generates a local `Budget2025.xlsx` workbook with monthly tabs (sorted from
+largest to smallest transaction), an `AllData` tab, and a manually generated
+`Summary` sheet that aggregates totals by month and category without using Excel
+PivotTables.
 
 ### Manual Transactions
 


### PR DESCRIPTION
## Summary
- sort monthly Excel worksheet data by largest transaction first
- replace Summary PivotTable with manual month/category aggregation
- document Excel output changes and update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bbb7ce1cbc832386710eb3efb82305