### PR TITLE
feat: add Go MCP server exposing transaction summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,20 @@ budgify-mcp
 
 This starts a FastMCP server exposing a single `run_budgify` tool.
 
+### Go MCP Server
+
+A lightweight HTTP server written in Go also exposes the transactions
+database via an MCP-friendly endpoint. Run it with:
+
+```bash
+go run transaction_tracker/go_mcp_server/main.go
+```
+
+Set the `BUDGIFY_DB` environment variable to point at your SQLite
+database (defaults to `budget.db`). The server listens on `:8080` and
+provides `/get_spend_by_category_month`, returning monthly totals by
+category in JSON.
+
 ## Extending
 
 ### Add a new bank loader

--- a/transaction_tracker/go_mcp_server/go.mod
+++ b/transaction_tracker/go_mcp_server/go.mod
@@ -1,0 +1,5 @@
+module github.com/example/budgify/go_mcp_server
+
+go 1.24
+
+require github.com/mattn/go-sqlite3 v1.14.22

--- a/transaction_tracker/go_mcp_server/go.sum
+++ b/transaction_tracker/go_mcp_server/go.sum
@@ -1,0 +1,2 @@
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/transaction_tracker/go_mcp_server/main.go
+++ b/transaction_tracker/go_mcp_server/main.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// OpenDB opens a SQLite database located at path.
+func OpenDB(path string) (*sql.DB, error) {
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+// GetSpendByCategoryMonth returns monthly spend aggregated by category.
+func GetSpendByCategoryMonth(db *sql.DB) ([]map[string]interface{}, error) {
+	rows, err := db.Query(`
+        SELECT strftime('%Y-%m', date) AS month,
+               category,
+               ROUND(SUM(amount), 2) AS total_spent
+        FROM transactions
+        GROUP BY month, category
+        ORDER BY month, category;
+    `)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []map[string]interface{}
+	for rows.Next() {
+		var month, category string
+		var total float64
+		if err := rows.Scan(&month, &category, &total); err != nil {
+			return nil, err
+		}
+		results = append(results, map[string]interface{}{
+			"month":       month,
+			"category":    category,
+			"total_spent": total,
+		})
+	}
+	return results, nil
+}
+
+// Server wraps the database and exposes HTTP handlers.
+type Server struct {
+	db *sql.DB
+}
+
+// NewServer creates a new Server.
+func NewServer(db *sql.DB) *Server {
+	return &Server{db: db}
+}
+
+// handleGetSpendByCategoryMonth writes the aggregated spend as JSON.
+func (s *Server) handleGetSpendByCategoryMonth(w http.ResponseWriter, r *http.Request) {
+	data, err := GetSpendByCategoryMonth(s.db)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		log.Printf("encode response: %v", err)
+	}
+}
+
+// routes registers HTTP routes.
+func (s *Server) routes() {
+	http.HandleFunc("/get_spend_by_category_month", s.handleGetSpendByCategoryMonth)
+}
+
+func main() {
+	dbPath := os.Getenv("BUDGIFY_DB")
+	if dbPath == "" {
+		dbPath = "budget.db"
+	}
+
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		log.Fatalf("failed to open db: %v", err)
+	}
+	defer db.Close()
+
+	server := NewServer(db)
+	server.routes()
+
+	log.Println("MCP server listening on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}


### PR DESCRIPTION
## Summary
- add Go HTTP MCP server to query spend by category and month
- document Go server usage and configuration

## Testing
- `go build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c50c113b3c8323acd2617c035b2f4b