### PR TITLE
Add MCP tool for querying SQLite transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,10 @@ invoke it directly. Install the optional `mcp` dependency and run:
 budgify-mcp
 ```
 
-This starts a FastMCP server exposing a single `run_budgify` tool.
+This starts a FastMCP server exposing:
+
+- `run_budgify` – process statements using the Budgify CLI.
+- `get_transactions` – fetch transactions from a SQLite database.
 
 ## Extending
 

--- a/tests/test_mcp_db.py
+++ b/tests/test_mcp_db.py
@@ -1,0 +1,23 @@
+import anyio
+from datetime import date
+
+from transaction_tracker.core.models import Transaction
+from transaction_tracker.database import append_transactions
+from transaction_tracker.mcp_server import get_transactions
+
+
+def test_get_transactions(tmp_path):
+    db_path = tmp_path / "txs.db"
+    txs = [
+        Transaction(date(2025, 5, 1), "Coffee", "Cafe", 3.5),
+        Transaction(date(2025, 5, 2), "Book", "Store", 12.0),
+    ]
+    append_transactions(txs, str(db_path))
+
+    all_rows = anyio.run(get_transactions, str(db_path))
+    assert len(all_rows) == 2
+    assert all_rows[0]["description"] == "Coffee"
+
+    filtered = anyio.run(get_transactions, str(db_path), "2025-05-02")
+    assert len(filtered) == 1
+    assert filtered[0]["merchant"] == "Store"


### PR DESCRIPTION
## Summary
- extend database module with `fetch_transactions` to read entries by date range
- expose new `get_transactions` tool via MCP server
- document MCP server tools and add tests for new functionality

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c51065c934832385a87e95f7107372