### PR TITLE
refactor: remove run_budgify tool from MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,6 @@ budgify-mcp
 
 This starts a FastMCP server exposing:
 
-- `run_budgify` – process statements using the Budgify CLI.
 - `get_transactions` – fetch transactions from a SQLite database.
 
 ## Extending

--- a/transaction_tracker/mcp_server.py
+++ b/transaction_tracker/mcp_server.py
@@ -6,35 +6,9 @@ from mcp.server.fastmcp import FastMCP
 from dataclasses import asdict
 from datetime import date
 
-from transaction_tracker.cli import main as cli
 from transaction_tracker.database import fetch_transactions
 
 server = FastMCP(name="Budgify", instructions="Expose Budgify as an MCP tool")
-
-@server.tool(name="run_budgify", description="Process statements using Budgify")
-async def run_budgify(
-    statements_dir: str,
-    output_format: str = "csv",
-    include_payments: bool = False,
-    config_path: str = "config.yaml",
-    manual_file: str | None = None,
-    env_file: str | None = None,
-    ai_report: bool = False,
-) -> str:
-    def _run() -> None:
-        cli.callback(
-            statements_dir,
-            output_format,
-            include_payments,
-            config_path,
-            manual_file,
-            env_file,
-            ai_report,
-        )
-
-    await anyio.to_thread.run_sync(_run)
-    return "Completed"
-
 
 @server.tool(
     name="get_transactions", description="Fetch transactions from the SQLite database"


### PR DESCRIPTION
## Summary
- remove `run_budgify` MCP tool, leaving only `get_transactions`
- update README to reflect reduced MCP server capabilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5eda302b4832398c326c91ddb3533