### PR TITLE
Expose categories and filtering in MCP server

### DIFF
--- a/tests/test_mcp_db.py
+++ b/tests/test_mcp_db.py
@@ -14,10 +14,12 @@ def test_get_transactions(tmp_path):
     ]
     append_transactions(txs, str(db_path))
 
-    all_rows = anyio.run(get_transactions, str(db_path))
-    assert len(all_rows) == 2
-    assert all_rows[0]["description"] == "Coffee"
+    all_rows = anyio.run(lambda: get_transactions(str(db_path)))
+    assert len(all_rows["transactions"]) == 2
+    assert all_rows["transactions"][0]["description"] == "Coffee"
 
-    filtered = anyio.run(get_transactions, str(db_path), "2025-05-02")
-    assert len(filtered) == 1
-    assert filtered[0]["merchant"] == "Store"
+    filtered = anyio.run(
+        lambda: get_transactions(str(db_path), start_date="2025-05-02")
+    )
+    assert len(filtered["transactions"]) == 1
+    assert filtered["transactions"][0]["merchant"] == "Store"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,57 @@
+import anyio
+from datetime import date
+
+from transaction_tracker.core.models import Transaction
+from transaction_tracker.database import append_transactions
+from transaction_tracker.mcp_server import (
+    get_categories,
+    get_transactions,
+    get_transactions_by_category_month,
+)
+
+
+def _setup_db(tmp_path):
+    db_path = tmp_path / "tx.db"
+    txs = [
+        Transaction(date(2025, 1, 10), "Grocery A", "Grocery A", 10),
+        Transaction(date(2025, 1, 15), "Restaurant X", "Restaurant X", 20),
+        Transaction(date(2025, 2, 5), "Grocery B", "Grocery B", 30),
+        Transaction(date(2025, 2, 10), "Restaurant Y", "Restaurant Y", 25),
+    ]
+    categories = {"groceries": ["grocery"], "restaurants": ["restaurant"]}
+    append_transactions(txs, db_path, categories)
+    return db_path
+
+
+def test_get_categories():
+    cats = anyio.run(get_categories)
+    assert "groceries" in cats
+    assert "restaurants" in cats
+
+
+def test_get_transactions_filters_and_sum(tmp_path):
+    db_path = _setup_db(tmp_path)
+
+    async def run():
+        return await get_transactions(
+            str(db_path), category="groceries", merchant_regex="Grocery B"
+        )
+
+    res = anyio.run(run)
+    assert res["total"] == 30
+    assert len(res["transactions"]) == 1
+    assert res["transactions"][0]["merchant"] == "Grocery B"
+
+
+def test_get_transactions_by_category_month(tmp_path):
+    db_path = _setup_db(tmp_path)
+
+    async def run():
+        return await get_transactions_by_category_month(str(db_path), "groceries")
+
+    res = anyio.run(run)
+    assert set(res.keys()) == {"2025-01", "2025-02"}
+    assert res["2025-01"]["total"] == 10
+    assert res["2025-02"]["total"] == 30
+    assert len(res["2025-01"]["transactions"]) == 1
+    assert len(res["2025-02"]["transactions"]) == 1

--- a/transaction_tracker/mcp_server.py
+++ b/transaction_tracker/mcp_server.py
@@ -1,24 +1,31 @@
 from __future__ import annotations
 
 import anyio
-from mcp.server.fastmcp import FastMCP
-
 from dataclasses import asdict
 from datetime import date
+from mcp.server.fastmcp import FastMCP
 
 from transaction_tracker.database import fetch_transactions
 
 server = FastMCP(name="Budgify", instructions="Expose Budgify as an MCP tool")
 
-@server.tool(
-    name="get_transactions", description="Fetch transactions from the SQLite database"
-)
+CATEGORIES = ["restaurants", "groceries", "fun", "fuel", "misc"]
+
+
+@server.tool(name="get_categories", description="List available transaction categories")
+async def get_categories() -> list[str]:
+    return CATEGORIES
+
+
+@server.tool(name="get_transactions", description="Fetch transactions from the SQLite database")
 async def get_transactions(
     db_path: str,
     start_date: str | None = None,
     end_date: str | None = None,
-) -> list[dict]:
-    """Return a list of transactions from ``db_path``.
+    category: str | None = None,
+    merchant_regex: str | None = None,
+) -> dict:
+    """Return transactions and total amount from ``db_path``.
 
     Parameters
     ----------
@@ -26,13 +33,45 @@ async def get_transactions(
         Path to the SQLite database file.
     start_date, end_date:
         Optional ISO formatted date strings bounding the query.
+    category:
+        Optional category name to filter transactions.
+    merchant_regex:
+        Optional regular expression to match merchant names.
     """
 
-    def _run() -> list[dict]:
+    def _run() -> dict:
         start = date.fromisoformat(start_date) if start_date else None
         end = date.fromisoformat(end_date) if end_date else None
-        txs = fetch_transactions(db_path, start, end)
-        return [asdict(t) for t in txs]
+        txs = fetch_transactions(
+            db_path,
+            start,
+            end,
+            category=category,
+            merchant_regex=merchant_regex,
+        )
+        data = [asdict(t) for t in txs]
+        total = sum(t.amount for t in txs)
+        return {"transactions": data, "total": total}
+
+    return await anyio.to_thread.run_sync(_run)
+
+
+@server.tool(
+    name="get_transactions_by_category_month",
+    description="Fetch transactions for a category grouped by month",
+)
+async def get_transactions_by_category_month(db_path: str, category: str) -> dict:
+    """Return transactions grouped by ``YYYY-MM`` for the given category."""
+
+    def _run() -> dict:
+        txs = fetch_transactions(db_path, category=category)
+        result: dict[str, dict] = {}
+        for t in txs:
+            key = t.date.strftime("%Y-%m")
+            bucket = result.setdefault(key, {"transactions": [], "total": 0.0})
+            bucket["transactions"].append(asdict(t))
+            bucket["total"] += t.amount
+        return result
 
     return await anyio.to_thread.run_sync(_run)
 


### PR DESCRIPTION
## Summary
- expose fixed transaction categories through new `get_categories` MCP tool
- extend `get_transactions` with category and merchant regex filters and return total amount
- add monthly category lookup tool and database support for filters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5f0ff1dfc8323a6cd8bf4488f6a7d