### PR TITLE
Improve MCP server input validation and error reporting

### DIFF
--- a/tests/test_mcp_db.py
+++ b/tests/test_mcp_db.py
@@ -1,5 +1,7 @@
-import anyio
 from datetime import date
+
+import anyio
+import pytest
 
 from transaction_tracker.core.models import Transaction
 from transaction_tracker.database import append_transactions
@@ -21,3 +23,25 @@ def test_get_transactions(tmp_path):
     filtered = anyio.run(get_transactions, str(db_path), "2025-05-02")
     assert len(filtered) == 1
     assert filtered[0]["merchant"] == "Store"
+
+
+def test_get_transactions_no_results(tmp_path):
+    db_path = tmp_path / "txs.db"
+    txs = [
+        Transaction(date(2025, 5, 1), "Coffee", "Cafe", 3.5),
+        Transaction(date(2025, 5, 2), "Book", "Store", 12.0),
+    ]
+    append_transactions(txs, str(db_path))
+
+    empty = anyio.run(get_transactions, str(db_path), "2024-01-01", "2024-01-31")
+    assert empty == []
+
+
+def test_get_transactions_bad_input(tmp_path):
+    db_path = tmp_path / "txs.db"
+
+    with pytest.raises(ValueError, match="Invalid start_date"):
+        anyio.run(get_transactions, str(db_path), "not-a-date")
+
+    with pytest.raises(ValueError, match="start_date must be on or before end_date"):
+        anyio.run(get_transactions, str(db_path), "2025-05-02", "2025-05-01")


### PR DESCRIPTION
## Summary
- add validation for date parsing, range checks, and database existence in MCP server
- ensure requesting out-of-range dates yields empty list
- add tests for missing transactions and invalid inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5f1d8a2cc83238956d0ccacb5bc0a