### PR TITLE
Add period comparison tool to MCP server

### DIFF
--- a/transaction_tracker/mcp_server.py
+++ b/transaction_tracker/mcp_server.py
@@ -8,13 +8,24 @@ from mcp.server.fastmcp import FastMCP
 
 from transaction_tracker.database import (
     category_insights,
+    compare_spend_between_periods,
     list_unique_merchants,
     summarize_by_category,
     summarize_by_merchant,
     summarize_by_period,
 )
 
-server = FastMCP(name="Budgify", instructions="Expose Budgify as an MCP tool")
+server = FastMCP(
+    name="Budgify",
+    instructions=(
+        "Budgify MCP server for querying transaction data.\n"
+        "Use ISO-8601 dates (YYYY-MM-DD) for every date argument; ranges are inclusive.\n"
+        "Valid `period` values are `month`, `quarter`, or `year`.\n"
+        "Examples:\n"
+        "- summarize_spend_by_period(db_path, period=\"month\", start_date=\"2025-01-01\", end_date=\"2025-03-31\")\n"
+        "- compare_spend_between_periods(db_path, first_start=\"2025-01-01\", first_end=\"2025-01-31\", second_start=\"2025-02-01\", second_end=\"2025-02-28\", category=\"groceries\")"
+    ),
+)
 
 CATEGORIES = [
     "subscription",
@@ -135,6 +146,33 @@ async def analyze_category_spend(
             end_date=_parse_date(end_date),
             top_merchants=top_merchants,
             top_transactions=top_transactions,
+        )
+
+    return await anyio.to_thread.run_sync(_run)
+
+
+@server.tool(
+    name="compare_spend_between_periods",
+    description=(
+        "Compare total spending between two date ranges, optionally for a specific category"
+    ),
+)
+async def compare_spend_between_periods_tool(
+    db_path: str,
+    first_start: str | None,
+    first_end: str | None,
+    second_start: str | None,
+    second_end: str | None,
+    category: str | None = None,
+) -> dict:
+    def _run() -> dict:
+        return compare_spend_between_periods(
+            db_path,
+            first_start=_parse_date(first_start),
+            first_end=_parse_date(first_end),
+            second_start=_parse_date(second_start),
+            second_end=_parse_date(second_end),
+            category=category,
         )
 
     return await anyio.to_thread.run_sync(_run)


### PR DESCRIPTION
## Summary
- add database helper to compare spending between two time ranges with optional category filtering
- expose the comparison via a new MCP tool and document date expectations and examples
- cover the new functionality with async MCP server tests for category-specific and overall comparisons

## Testing
- pytest tests/test_mcp_server.py

------
https://chatgpt.com/codex/tasks/task_e_68e47a58f3888323948f63abf9fe214c